### PR TITLE
Typescript: allow defineMessages(... as const) syntax

### DIFF
--- a/src/utils/getMessages.js
+++ b/src/utils/getMessages.js
@@ -6,7 +6,13 @@ import { objectExpressionToObject } from './ast-helper';
 export default function getMessages(
   referencePath: BabelPath,
 ): Array<MessageDescriptor> {
-  const properties = referencePath.parentPath.get('arguments.0.properties');
+  const arg0 = referencePath.parentPath.get('arguments.0');
+
+  const properties =
+    arg0.type === 'TSAsExpression'
+      ? arg0.get('expression.properties')
+      : arg0.get('properties');
+
   const messages = properties
     .map(property => property.get('value'))
     .map(objectExpressionToObject);


### PR DESCRIPTION
This PR fixes edge case with `as const` typescript type modifier like this:

```ts
import { defineMessages } from 'react-intl.macro';

const msg = defineMessages({
    name: { id: 'common.name', defaultMessage: 'Name' },
    surname: { id: 'common.surname', defaultMessage: 'Surname' },
} as const);

export default messages;
```

This is very useful in IDE, you can see `id` and `defaultMessage` by hovering prop:
![image](https://user-images.githubusercontent.com/142462/69389119-61631800-0ccb-11ea-964c-5a57471d5fc2.png)

BTW I'm using this type definitions, I will add enhanced `.d.ts` to new PR
```ts
declare module 'react-intl.macro' {
    interface MessageDescriptor {
        readonly id: string;
        readonly defaultMessage: string;
        readonly description?: string;
    }

    interface Messages {
        readonly [K: string]: MessageDescriptor;
    }

    export function defineMessages<T extends Messages>(messages: T): T;
}
```